### PR TITLE
make UI usable without mouse (+gamepad support)

### DIFF
--- a/ui/inventory_system_ui.gd
+++ b/ui/inventory_system_ui.gd
@@ -140,7 +140,7 @@ func _slot_point_down(event : InputEvent, slot_index : int, inventory : Inventor
 			return
 		var slot = inventory.slots[slot_index]
 		var amount = slot.amount
-		if event.button_index == 2:
+		if event is InputEventMouseButton and event.button_index == 2:
 			amount = ceili(slot.amount/2.0)
 		inventory_handler.to_transaction(slot_index, inventory, amount)	
 		$SlotClick.play()

--- a/ui/inventory_system_ui.gd
+++ b/ui/inventory_system_ui.gd
@@ -82,9 +82,11 @@ func _drop_area_input(event : InputEvent):
 
 
 func _open_player_inventory():
-	player_inventory_ui.visible = true;
+	player_inventory_ui.visible = true
 	hotbar_ui.visible = false
 	drop_area.visible = true
+	if not player_inventory_ui.slots.is_empty():
+		player_inventory_ui.slots[0].grab_focus()
 
 
 # Open Inventory of player	

--- a/ui/inventory_ui.gd
+++ b/ui/inventory_ui.gd
@@ -69,22 +69,24 @@ func _update_slots():
 
 	## Set focus neighbors
 	for slot_idx in slots.size():
-		var neighbor_idxs = {left = slot_idx-1,top = slot_idx-slots_container.columns,right = slot_idx+1,bottom = slot_idx+slots_container.columns}
 		var slot = slots[slot_idx]
-		for neighbor in neighbor_idxs.keys():
-			var nb_idx = neighbor_idxs[neighbor]
-			if nb_idx >= 0 and nb_idx < slots.size():
-				match neighbor:
-					"left":
-						if slot_idx % slots_container.columns != 0:
-							slot.focus_neighbor_left = slots[nb_idx].get_path()
-					"top":
-						slot.focus_neighbor_top = slots[nb_idx].get_path()
-					"right":
-						if nb_idx % slots_container.columns != 0:
-							slot.focus_neighbor_right = slots[nb_idx].get_path()
-					"bottom":
-						slot.focus_neighbor_bottom = slots[nb_idx].get_path()
+		for neighbor in ["left", "top", "right", "bottom"]:
+			var neighbor_idx: int
+			match neighbor:
+				"left":
+					neighbor_idx = slot_idx - 1
+					if slot_idx % slots_container.columns == 0:
+						neighbor_idx = -1
+				"top":
+					neighbor_idx = slot_idx - slots_container.columns
+				"right":
+					neighbor_idx = slot_idx + 1
+					if (slot_idx + 1) % slots_container.columns == 0:
+						neighbor_idx = -1
+				"bottom":
+					neighbor_idx = slot_idx + slots_container.columns
+			if neighbor_idx >= 0 and neighbor_idx < slots.size():
+				slot.set("focus_neighbor_"+neighbor, slots[neighbor_idx].get_path())
 
 
 func _on_updated_slot(index):

--- a/ui/inventory_ui.gd
+++ b/ui/inventory_ui.gd
@@ -67,6 +67,25 @@ func _update_slots():
 		slots.append(slot_obj)
 		slot_obj.update_info_with_slot(slot)
 
+	## Set focus neighbors
+	for slot_idx in slots.size():
+		var neighbor_idxs = {left = slot_idx-1,top = slot_idx-slots_container.columns,right = slot_idx+1,bottom = slot_idx+slots_container.columns}
+		var slot = slots[slot_idx]
+		for neighbor in neighbor_idxs.keys():
+			var nb_idx = neighbor_idxs[neighbor]
+			if nb_idx >= 0 and nb_idx < slots.size():
+				match neighbor:
+					"left":
+						if slot_idx % slots_container.columns != 0:
+							slot.focus_neighbor_left = slots[nb_idx].get_path()
+					"top":
+						slot.focus_neighbor_top = slots[nb_idx].get_path()
+					"right":
+						if nb_idx % slots_container.columns != 0:
+							slot.focus_neighbor_right = slots[nb_idx].get_path()
+					"bottom":
+						slot.focus_neighbor_bottom = slots[nb_idx].get_path()
+
 
 func _on_updated_slot(index):
 	slots[index].update_info_with_slot(inventory.slots[index])
@@ -85,7 +104,7 @@ func _on_slot_removed(index):
 
 
 func _on_slot_gui_input(event : InputEvent, slot_obj):
-	if event is InputEventMouseButton:
+	if event is InputEventMouseButton or event.is_action("ui_accept"):
 		if event.pressed:	
 			var index = slots.find(slot_obj)
 			if index < 0:

--- a/ui/slot_ui.gd
+++ b/ui/slot_ui.gd
@@ -68,12 +68,20 @@ func set_selection(is_selected : bool):
 
 
 func _on_mouse_entered():
-	$Panel.self_modulate = highlight_color
+	grab_focus()
 
 
 func _on_mouse_exited():
-	$Panel.self_modulate = Color.WHITE
+	release_focus()
 
 
 func _on_hidden():
+	release_focus()
+
+
+func _on_focus_entered() -> void:
+	$Panel.self_modulate = highlight_color
+
+
+func _on_focus_exited() -> void:
 	$Panel.self_modulate = Color.WHITE

--- a/ui/transaction_slot.gd
+++ b/ui/transaction_slot.gd
@@ -9,7 +9,11 @@ func _ready():
 func update_info_with_item(item : InventoryItem, amount := 1):
 	super.update_info_with_item(item, amount)
 	visible = amount > 0
-	self.global_position = get_global_mouse_position() - size/2
+	if get_viewport().gui_get_focus_owner():
+		self.global_position = get_viewport().gui_get_focus_owner().global_position
+	else:
+		self.global_position = get_global_mouse_position() - size/2
+	
 	$DropIcon.visible = false
 	
 func clear_info():
@@ -19,9 +23,11 @@ func clear_info():
 	
 func _process(delta):
 	if self.visible:
-		self.global_position = get_global_mouse_position() - size/2
-
-
+		if get_viewport().gui_get_focus_owner():
+			self.global_position = get_viewport().gui_get_focus_owner().global_position
+		else:
+			self.global_position = get_global_mouse_position() - size/2
+			
 func _on_drop_area_mouse_exited():
 	$DropIcon.visible = false
 

--- a/ui/transaction_slot.gd
+++ b/ui/transaction_slot.gd
@@ -10,7 +10,6 @@ func update_info_with_item(item : InventoryItem, amount := 1):
 	super.update_info_with_item(item, amount)
 	visible = amount > 0
 	self.global_position = get_global_mouse_position() - size/2
-	
 	$DropIcon.visible = false
 	
 func clear_info():

--- a/ui/transaction_slot.gd
+++ b/ui/transaction_slot.gd
@@ -9,10 +9,7 @@ func _ready():
 func update_info_with_item(item : InventoryItem, amount := 1):
 	super.update_info_with_item(item, amount)
 	visible = amount > 0
-	if get_viewport().gui_get_focus_owner():
-		self.global_position = get_viewport().gui_get_focus_owner().global_position
-	else:
-		self.global_position = get_global_mouse_position() - size/2
+	self.global_position = get_global_mouse_position() - size/2
 	
 	$DropIcon.visible = false
 	


### PR DESCRIPTION
All the changes happen inside the plugin as I think it is just as low level as mouse controls and would be very hard to just do them externally in the demo.
One thing that comes with it, but could be moved to an optional global setting, is that the dragged items always snap to hovered slots. However I personally do not dislike that.
In the demo there is just a few settings in the slot_ui.tscn(focus mode and signal connections): https://github.com/expressobits/inventory-system-demos/commit/356cc36d46adca39cfc295e67849b72c7ff52429
I can make a pull request there if this gets implemented here.
I hope you are okay with the way I did it but I would still be open to a different approach.