### PR TITLE
fix linked variables in newly created items

### DIFF
--- a/editor/items/items_editor.gd
+++ b/editor/items/items_editor.gd
@@ -104,6 +104,8 @@ func _on_item_editor_changed(id):
 
 func _on_new_resource_dialog_file_selected(path):
 	var item : InventoryItem = InventoryItem.new()
+	item.properties = {}
+	item.categories = []
 	var err = ResourceSaver.save(item, path)
 	if err == OK:
 		item = load(path)


### PR DESCRIPTION
Fixes a bug where newly created item properties and categories are not unique per instance.