### PR TITLE
make item type select button not reset AND improve item editor UI

### DIFF
--- a/editor/items/custom_properties.gd
+++ b/editor/items/custom_properties.gd
@@ -15,7 +15,7 @@ var properties_obj : Array
 
 func _ready():
 	add_button.disabled = line_edit.text.is_empty()
-
+	build_type_options();
 
 func load_item(database : InventoryDatabase, item : InventoryItem):
 	self.database = database
@@ -42,7 +42,6 @@ func loading_properties():
 			properties_obj.append(property_obj)
 			v_box_container.add_child(property_obj)
 	item.properties = new_item_properties
-	build_type_options();
 
 
 func build_type_options():

--- a/editor/items/item_editor.gd
+++ b/editor/items/item_editor.gd
@@ -8,7 +8,7 @@ var item : InventoryItem
 var database : InventoryDatabase
 var editor_plugin : EditorPlugin
 
-@onready var item_id_editor : ItemIDEditor = $MarginContainer/VBoxContainer/ItemIDEditor
+@onready var item_id_editor : ItemIDEditor = $ScrollContainer/MarginContainer/VBoxContainer/ItemIDEditor
 @onready var item_name_text_edit : LineEdit = %ItemNameTextEdit
 @onready var item_max_stack_spin_box : SpinBox = %MaxStackSpinBox
 @onready var item_icon_text_edit : LineEdit = %IconLineEdit
@@ -17,14 +17,14 @@ var editor_plugin : EditorPlugin
 @onready var item_resource_text_edit : LineEdit = %ItemResourceLineEdit
 @onready var item_resource_edit_button : Button = %ItemResourceEditButton
 @onready var item_resource_file_dialog : FileDialog = $ItemResourceFileDialog
-@onready var custom_properties : CustomPropertiesItemEditor = $MarginContainer/VBoxContainer/CustomProperties
-@onready var weight_spin_box = $MarginContainer/VBoxContainer/Weight/WeightSpinBox
-@onready var categories_in_item : CategoriesInItem = $MarginContainer/VBoxContainer/CategoriesInItem
+@onready var custom_properties : CustomPropertiesItemEditor = $ScrollContainer/MarginContainer/VBoxContainer/CustomProperties
+@onready var weight_spin_box = $ScrollContainer/MarginContainer/VBoxContainer/Weight/WeightSpinBox
+@onready var categories_in_item : CategoriesInItem = $ScrollContainer/MarginContainer/VBoxContainer/CategoriesInItem
 
 
 func _ready():
 	apply_theme()
-	$MarginContainer.visible = false
+	$ScrollContainer.visible = false
 
 
 func set_editor_plugin(editor_plugin : EditorPlugin):
@@ -36,7 +36,7 @@ func load_item(item : InventoryItem, database : InventoryDatabase):
 	self.item = item
 	self.database = database
 	if not is_instance_valid(item):
-		$MarginContainer.visible = false
+		$ScrollContainer.visible = false
 		return
 	item_id_editor.setup(database, item.id)
 	if is_instance_valid(item):
@@ -48,11 +48,11 @@ func load_item(item : InventoryItem, database : InventoryDatabase):
 			item_icon_text_edit.text = item.icon.resource_path
 		else:
 			item_icon_text_edit.text = ""
-		$MarginContainer.visible = true
+		$ScrollContainer.visible = true
 	else:
 		item_resource_text_edit.text = "No resource path item!"
 		item_name_text_edit.text = "No resource item!"
-		$MarginContainer.visible = false
+		$ScrollContainer.visible = false
 		
 	custom_properties.load_item(database, item)
 	categories_in_item.load_item(database, item)

--- a/editor/items/item_editor.tscn
+++ b/editor/items/item_editor.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="PackedScene" uid="uid://bl40ri4you0n5" path="res://addons/inventory-system/editor/items/categories_in_item.tscn" id="3_cy8bj"]
 [ext_resource type="PackedScene" uid="uid://c1am6gfdvbcgx" path="res://addons/inventory-system/editor/items/custom_properties.tscn" id="3_obam6"]
 
-[sub_resource type="Image" id="Image_psmrr"]
+[sub_resource type="Image" id="Image_mq8r0"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 93, 93, 55, 255, 97, 97, 58, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 98, 98, 47, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 94, 94, 46, 255, 93, 93, 236, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -15,9 +15,9 @@ data = {
 }
 
 [sub_resource type="ImageTexture" id="ImageTexture_uoasd"]
-image = SubResource("Image_psmrr")
+image = SubResource("Image_mq8r0")
 
-[sub_resource type="Image" id="Image_6xike"]
+[sub_resource type="Image" id="Image_nwtfv"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -26,8 +26,8 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_nsx0d"]
-image = SubResource("Image_6xike")
+[sub_resource type="ImageTexture" id="ImageTexture_bcwua"]
+image = SubResource("Image_nwtfv")
 
 [node name="ItemEditor" type="Control"]
 custom_minimum_size = Vector2(256, 0)
@@ -36,30 +36,37 @@ anchors_preset = 0
 offset_right = 512.0
 script = ExtResource("1_smo60")
 
-[node name="MarginContainer" type="MarginContainer" parent="."]
+[node name="ScrollContainer" type="ScrollContainer" parent="."]
+visible = false
 layout_mode = 1
-anchors_preset = 10
+anchors_preset = 15
 anchor_right = 1.0
-offset_bottom = 381.0
+anchor_bottom = 1.0
 grow_horizontal = 2
+grow_vertical = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 theme_override_constants/margin_left = 4
 theme_override_constants/margin_top = 4
 theme_override_constants/margin_right = 4
 theme_override_constants/margin_bottom = 4
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="ScrollContainer/MarginContainer"]
 layout_mode = 2
 
-[node name="ItemResource" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+[node name="ItemResource" type="HBoxContainer" parent="ScrollContainer/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/ItemResource"]
+[node name="Label" type="Label" parent="ScrollContainer/MarginContainer/VBoxContainer/ItemResource"]
 custom_minimum_size = Vector2(128, 0)
 layout_mode = 2
 text = "Item Resource"
 
-[node name="ItemResourceLineEdit" type="LineEdit" parent="MarginContainer/VBoxContainer/ItemResource"]
+[node name="ItemResourceLineEdit" type="LineEdit" parent="ScrollContainer/MarginContainer/VBoxContainer/ItemResource"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
@@ -67,7 +74,7 @@ size_flags_horizontal = 3
 placeholder_text = "Place Item Resource Path Here"
 editable = false
 
-[node name="ItemResourceEditButton" type="Button" parent="MarginContainer/VBoxContainer/ItemResource"]
+[node name="ItemResourceEditButton" type="Button" parent="ScrollContainer/MarginContainer/VBoxContainer/ItemResource"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(32, 32)
 layout_mode = 2
@@ -76,54 +83,54 @@ icon = SubResource("ImageTexture_uoasd")
 flat = true
 icon_alignment = 1
 
-[node name="ItemIDEditor" parent="MarginContainer/VBoxContainer" instance=ExtResource("2_s4m1x")]
+[node name="ItemIDEditor" parent="ScrollContainer/MarginContainer/VBoxContainer" instance=ExtResource("2_s4m1x")]
 layout_mode = 2
 
-[node name="Label" parent="MarginContainer/VBoxContainer/ItemIDEditor" index="0"]
+[node name="Label" parent="ScrollContainer/MarginContainer/VBoxContainer/ItemIDEditor" index="0"]
 custom_minimum_size = Vector2(128, 0)
 
-[node name="Button" parent="MarginContainer/VBoxContainer/ItemIDEditor" index="2"]
+[node name="Button" parent="ScrollContainer/MarginContainer/VBoxContainer/ItemIDEditor" index="2"]
 tooltip_text = "Edit"
-icon = SubResource("ImageTexture_nsx0d")
+icon = SubResource("ImageTexture_bcwua")
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="ScrollContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="Label" type="Label" parent="ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer"]
 custom_minimum_size = Vector2(128, 0)
 layout_mode = 2
 text = "Item Name"
 
-[node name="ItemNameTextEdit" type="LineEdit" parent="MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="ItemNameTextEdit" type="LineEdit" parent="ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
 size_flags_horizontal = 3
 placeholder_text = "Place Item Name Here"
 
-[node name="MaxStack" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+[node name="MaxStack" type="HBoxContainer" parent="ScrollContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/MaxStack"]
+[node name="Label" type="Label" parent="ScrollContainer/MarginContainer/VBoxContainer/MaxStack"]
 custom_minimum_size = Vector2(128, 0)
 layout_mode = 2
 text = "Item Max Stack"
 
-[node name="MaxStackSpinBox" type="SpinBox" parent="MarginContainer/VBoxContainer/MaxStack"]
+[node name="MaxStackSpinBox" type="SpinBox" parent="ScrollContainer/MarginContainer/VBoxContainer/MaxStack"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Weight" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+[node name="Weight" type="HBoxContainer" parent="ScrollContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/Weight"]
+[node name="Label" type="Label" parent="ScrollContainer/MarginContainer/VBoxContainer/Weight"]
 custom_minimum_size = Vector2(128, 0)
 layout_mode = 2
 text = "Item Weight"
 
-[node name="WeightSpinBox" type="SpinBox" parent="MarginContainer/VBoxContainer/Weight"]
+[node name="WeightSpinBox" type="SpinBox" parent="ScrollContainer/MarginContainer/VBoxContainer/Weight"]
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -131,21 +138,21 @@ step = 0.001
 allow_greater = true
 allow_lesser = true
 
-[node name="Icon" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+[node name="Icon" type="HBoxContainer" parent="ScrollContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/Icon"]
+[node name="Label" type="Label" parent="ScrollContainer/MarginContainer/VBoxContainer/Icon"]
 custom_minimum_size = Vector2(128, 0)
 layout_mode = 2
 text = "Icon"
 
-[node name="IconLineEdit" type="LineEdit" parent="MarginContainer/VBoxContainer/Icon"]
+[node name="IconLineEdit" type="LineEdit" parent="ScrollContainer/MarginContainer/VBoxContainer/Icon"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 editable = false
 
-[node name="IconEditButton" type="Button" parent="MarginContainer/VBoxContainer/Icon"]
+[node name="IconEditButton" type="Button" parent="ScrollContainer/MarginContainer/VBoxContainer/Icon"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(32, 32)
 layout_mode = 2
@@ -154,18 +161,18 @@ icon = SubResource("ImageTexture_uoasd")
 flat = true
 icon_alignment = 1
 
-[node name="HSeparator2" type="HSeparator" parent="MarginContainer/VBoxContainer"]
+[node name="HSeparator2" type="HSeparator" parent="ScrollContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="CategoriesInItem" parent="MarginContainer/VBoxContainer" instance=ExtResource("3_cy8bj")]
+[node name="CategoriesInItem" parent="ScrollContainer/MarginContainer/VBoxContainer" instance=ExtResource("3_cy8bj")]
 layout_mode = 2
 
-[node name="HSeparator3" type="HSeparator" parent="MarginContainer/VBoxContainer"]
+[node name="HSeparator3" type="HSeparator" parent="ScrollContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="CustomProperties" parent="MarginContainer/VBoxContainer" instance=ExtResource("3_obam6")]
+[node name="CustomProperties" parent="ScrollContainer/MarginContainer/VBoxContainer" instance=ExtResource("3_obam6")]
 layout_mode = 2
 
 [node name="ItemResourceFileDialog" type="FileDialog" parent="."]
@@ -197,16 +204,16 @@ file_mode = 0
 filters = PackedStringArray("*.tscn ; PackedScene")
 
 [connection signal="theme_changed" from="." to="." method="_on_theme_changed"]
-[connection signal="text_changed" from="MarginContainer/VBoxContainer/ItemResource/ItemResourceLineEdit" to="." method="_on_item_resource_line_edit_text_changed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/ItemResource/ItemResourceEditButton" to="." method="_on_item_resource_edit_button_pressed"]
-[connection signal="changed" from="MarginContainer/VBoxContainer/ItemIDEditor" to="." method="_on_item_id_editor_changed"]
-[connection signal="text_changed" from="MarginContainer/VBoxContainer/HBoxContainer/ItemNameTextEdit" to="." method="_on_text_edit_text_changed"]
-[connection signal="value_changed" from="MarginContainer/VBoxContainer/MaxStack/MaxStackSpinBox" to="." method="_on_max_stack_spin_box_value_changed"]
-[connection signal="value_changed" from="MarginContainer/VBoxContainer/Weight/WeightSpinBox" to="." method="_on_weight_spin_box_value_changed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/Icon/IconEditButton" to="." method="_on_icon_edit_button_pressed"]
+[connection signal="text_changed" from="ScrollContainer/MarginContainer/VBoxContainer/ItemResource/ItemResourceLineEdit" to="." method="_on_item_resource_line_edit_text_changed"]
+[connection signal="pressed" from="ScrollContainer/MarginContainer/VBoxContainer/ItemResource/ItemResourceEditButton" to="." method="_on_item_resource_edit_button_pressed"]
+[connection signal="changed" from="ScrollContainer/MarginContainer/VBoxContainer/ItemIDEditor" to="." method="_on_item_id_editor_changed"]
+[connection signal="text_changed" from="ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer/ItemNameTextEdit" to="." method="_on_text_edit_text_changed"]
+[connection signal="value_changed" from="ScrollContainer/MarginContainer/VBoxContainer/MaxStack/MaxStackSpinBox" to="." method="_on_max_stack_spin_box_value_changed"]
+[connection signal="value_changed" from="ScrollContainer/MarginContainer/VBoxContainer/Weight/WeightSpinBox" to="." method="_on_weight_spin_box_value_changed"]
+[connection signal="pressed" from="ScrollContainer/MarginContainer/VBoxContainer/Icon/IconEditButton" to="." method="_on_icon_edit_button_pressed"]
 [connection signal="file_selected" from="ItemResourceFileDialog" to="." method="_on_item_resource_file_dialog_file_selected"]
 [connection signal="file_selected" from="IconFileDialog" to="." method="_on_icon_file_dialog_file_selected"]
 [connection signal="file_selected" from="HandItemFileDialog" to="." method="_on_hand_item_file_dialog_file_selected"]
 [connection signal="file_selected" from="DroppedItemFileDialog" to="." method="_on_dropped_item_file_dialog_file_selected"]
 
-[editable path="MarginContainer/VBoxContainer/ItemIDEditor"]
+[editable path="ScrollContainer/MarginContainer/VBoxContainer/ItemIDEditor"]


### PR DESCRIPTION
**make item type select button not reset when add new property or when delete property**
in editor/items/custom_properties.gd

just a small change

I found that select type button in custom property section is always keep reset
so I make that not reset when add new property or when delete property

***GIF

BEFORE
![crop improve item editor UI - before](https://github.com/expressobits/inventory-system/assets/67323548/b9e4fea0-ea09-4084-b696-0c66bab2ed71)

AFTER
![crop property type button - after](https://github.com/expressobits/inventory-system/assets/67323548/d1305770-d725-42a9-b263-af99ad04b553)

and others are **improve item editor UI**

1. do item editor can scroll
2. do custom property can expand to bottom edge

***GIF

BEFORE
![improve item editor UI - before](https://github.com/expressobits/inventory-system/assets/67323548/07dfd5db-a7b1-45cb-a361-5e84fc4c9244)

AFTER
![improve item editor UI - after](https://github.com/expressobits/inventory-system/assets/67323548/660e655d-291e-4dea-a517-02d9f5e0bf63)
