### PR TITLE
Fixed an issue where adding InventoryItems created outside the UI overwrote the Item with ID=0

### DIFF
--- a/editor/items/items_editor.gd
+++ b/editor/items/items_editor.gd
@@ -125,6 +125,8 @@ func _on_open_resource_dialog_file_selected(path):
 		if database.items.has(item):
 			push_warning("The item \""+item.name+"\"("+ item.resource_path +") already exists in the database!")
 			return
+		if database.has_item_id(item.id):
+			item.id = database.get_new_valid_id()
 		database.add_new_item(item)
 		ResourceSaver.save(database, database.resource_path)
 		load_items()


### PR DESCRIPTION
Adding an InventoryItem to the UI that was created outside the Inventory UI will now correctly update the ID instead of overwriting the item with id=0