### PR TITLE
Assure inventory system changes

### DIFF
--- a/addons/inventory-system/ui/inventory_system_ui.gd
+++ b/addons/inventory-system/ui/inventory_system_ui.gd
@@ -41,6 +41,10 @@ var interactor : InventoryInteractor
 
 
 func _ready():
+	_on_inventory_handler_changed()
+	_on_crafter_changed()
+	_on_interactor_changed()
+	_on_hotbar_changed()
 	InventorySystem.inventory_handler_changed.connect(_on_inventory_handler_changed.bind())
 	InventorySystem.crafter_changed.connect(_on_crafter_changed.bind())
 	InventorySystem.interactor_changed.connect(_on_interactor_changed.bind())


### PR DESCRIPTION
Hi, I tried out the addon the first time today. Nice work so far :)

I noticed that if `CharacterInventorySystem `is readied before the `InventorySystemUI `then no handler, no crafter and so on is set.
This I fixed by calling the changed functions.
I am not sure whether the _addon_ branch is right here ...