### PR TITLE
Fix invalid main inventory access in demo

### DIFF
--- a/fps/fps_demo.gd
+++ b/fps/fps_demo.gd
@@ -6,19 +6,20 @@ class_name FPSDemo
 @export var item_grass : InventoryItem
 @export var database : InventoryDatabase
 
+@onready var main_inventory: Inventory = InventorySystem.inventory_handler.inventories[0]
 
 func _process(_delta):
 	if Input.is_action_just_released("add_item_a"):
-		InventorySystem.inventory_handler.add_to_inventory(InventorySystem.inventory_handler.inventory, item_wood, 1)
+		InventorySystem.inventory_handler.add_to_inventory(main_inventory, item_wood, 1)
 	if Input.is_action_just_released("remove_item_a"):
-		InventorySystem.inventory_handler.inventory.remove(item_wood, 1)
+		main_inventory.remove(item_wood, 1)
 		
 	if Input.is_action_just_released("add_item_b"):
-		InventorySystem.inventory_handler.add_to_inventory(InventorySystem.inventory_handler.inventory, item_stone, 1)
+		InventorySystem.inventory_handler.add_to_inventory(main_inventory, item_stone, 1)
 	if Input.is_action_just_released("remove_item_b"):
-		InventorySystem.inventory_handler.inventory.remove(item_stone, 1)
+		main_inventory.remove(item_stone, 1)
 		
 	if Input.is_action_just_released("add_item_c"):
-		InventorySystem.inventory_handler.add_to_inventory(InventorySystem.inventory_handler.inventory, item_grass, 1)
+		InventorySystem.inventory_handler.add_to_inventory(main_inventory, item_grass, 1)
 	if Input.is_action_just_released("remove_item_c"):
-		InventorySystem.inventory_handler.inventory.remove(item_grass, 1)
+		main_inventory.remove(item_grass, 1)

--- a/fps/fps_demo.tscn
+++ b/fps/fps_demo.tscn
@@ -12,7 +12,7 @@
 [ext_resource type="PackedScene" uid="uid://ds8coutyid33j" path="res://assets/survival-kit-1.1/Models/GLTF format/workbenchGrind.glb" id="9_ltu3q"]
 [ext_resource type="Script" path="res://base/setup_keys.gd" id="10_1ncja"]
 [ext_resource type="PackedScene" uid="uid://dxm5l6pst55ip" path="res://assets/survival-kit-1.1/Models/GLTF format/workbenchAnvil.glb" id="10_ds5rh"]
-[ext_resource type="Resource" path="res://base/categories/tool.tres" id="10_n1hfr"]
+[ext_resource type="Resource" uid="uid://b5xbt36cc6cji" path="res://base/categories/tool.tres" id="10_n1hfr"]
 [ext_resource type="PackedScene" uid="uid://bvjagvllelgcf" path="res://fps/workbench.tscn" id="11_fkc5i"]
 [ext_resource type="Script" path="res://addons/inventory-system/core/categorized_slot.gd" id="11_ntpr3"]
 [ext_resource type="Resource" uid="uid://1g5wqbk7eo0d" path="res://base/items/helmet_labor.tres" id="12_hloea"]


### PR DESCRIPTION
I found this add-on today and I'm very much loving how clean and readable the code is. Amazing work! Hoping to make good use of it 🙂

I noticed the F1-F6 buttons were broken in demo, so, figured I'd tackle this to better understand the system.
![image](https://github.com/expressobits/inventory-system/assets/46084870/e248ab31-981a-4f9f-b6ec-20c8e20ce476)

Introduced with the removal of `InventoryHandler::inventory` in favour of `InventoryHandler::inventories` last week (https://github.com/expressobits/inventory-system/commit/4b6005a397c355dc20ebd0b9d215f9275bb52529#)

`InventoryHandler` already has the concept of "main inventory" all over the place, but is repeatedly accessed as `inventories[0]`. Maybe this should be moved to a function or variable? I did notice `InventoryHandler::inventory_path` which _is_ the main inventory in this specific case, but it's typed as a `NodePath` instead of `Inventory`.

✌️ 