### PR TITLE
Made some changes to fix crash from issues/126

### DIFF
--- a/src/core/inventory.cpp
+++ b/src/core/inventory.cpp
@@ -167,23 +167,45 @@ int Inventory::get_amount() const {
 }
 
 int Inventory::add(const Ref<Item> &item, const int &amount) {
+	ERR_FAIL_NULL_V_MSG(item, amount, "The 'item' is null.");
+	ERR_FAIL_COND_V_MSG(amount < 0, amount, "The 'amount' is negative.");
+
 	int amount_in_interact = amount;
 	int old_amount = get_amount();
+
 	for (size_t i = 0; i < slots.size(); i++) {
+		int previous_amount = amount_in_interact;
 		amount_in_interact = _add_to_slot(i, item, amount_in_interact);
+
+		// Check for potential integer underflow
+		ERR_FAIL_COND_V_MSG(amount_in_interact > previous_amount, amount, "Integer underflow detected in _add_to_slot.");
+
 		if (amount_in_interact == 0) {
 			break;
 		}
 	}
+
 	if (create_slot_if_needed && amount_in_interact > 0) {
 		add_slot(slots.size());
+		int previous_amount = amount_in_interact;
 		amount_in_interact = _add_to_slot(slots.size() - 1, item, amount_in_interact);
+
+		// Check for potential integer underflow
+		ERR_FAIL_COND_V_MSG(amount_in_interact > previous_amount, amount, "Integer underflow detected in _add_to_slot after creating new slot.");
+
 		_call_events(old_amount);
 	}
+
+	// Use subtraction to avoid potential overflow
 	int _added = amount - amount_in_interact;
+
+	// Sanity check
+	ERR_FAIL_COND_V_MSG(_added < 0 || _added > amount, amount, "Invalid _added value calculated.");
+
 	if (_added > 0) {
 		emit_signal("item_added", item, _added);
 	}
+
 	return amount_in_interact;
 }
 
@@ -392,18 +414,24 @@ void Inventory::_call_events(int old_amount) {
 }
 
 int Inventory::_add_to_slot(int slot_index, const Ref<Item> &item, int amount) {
-	ERR_FAIL_COND_V_MSG(slot_index >= size(), 0, "The 'slot index' exceeds the inventory size.");
+	// Check if slot_index is within valid range (0 <= slot_index < size())
+	ERR_FAIL_COND_V_MSG(slot_index < 0 || slot_index >= size(), 0, "The 'slot index' is out of bounds.");
 	ERR_FAIL_NULL_V_MSG(item, 0, "The 'item' is null.");
 	ERR_FAIL_COND_V_MSG(amount < 0, 0, "The 'amount' is negative.");
+
 	Ref<Slot> slot = slots[slot_index];
-	ERR_FAIL_NULL_V_MSG(slot, 0, "The 'amount' is negative.");
+	ERR_FAIL_NULL_V_MSG(slot, 0, "The 'slot' is null.");
+
 	int _remaining_amount = slot->add(item, amount);
+
 	if (_remaining_amount == amount) {
 		return amount;
 	}
+
 	emit_signal("updated_slot", slot_index);
 	return _remaining_amount;
 }
+
 
 int Inventory::_remove_from_slot(int slot_index, const Ref<Item> &item, int amount) {
 	Ref<Slot> slot = slots[slot_index];

--- a/src/core/inventory_handler.cpp
+++ b/src/core/inventory_handler.cpp
@@ -50,8 +50,8 @@ InventoryHandler::~InventoryHandler() {
 
 void InventoryHandler::_ready() {
 	if (!Engine::get_singleton()->is_editor_hint()) {
-		if(transaction_slot == nullptr) {
-			set_transaction_slot(memnew(Slot()));
+		if(transaction_slot.is_null()) {
+			set_transaction_slot(Ref<Slot> (memnew(Slot())));
 		}
 	}
 	NodeInventories::_ready();
@@ -82,19 +82,23 @@ TypedArray<NodePath> InventoryHandler::get_opened_inventories() const {
 }
 
 void InventoryHandler::change_transaction_slot(const Ref<Item> &item, const int &amount) {
+	ERR_FAIL_COND(transaction_slot.is_null());
 	transaction_slot->set_amount(amount);
-	if (amount > 0) {
+	if (amount > 0 && item.is_valid()) {
 		transaction_slot->set_item(item);
 	} else {
-		transaction_slot->set_item(nullptr);
+		transaction_slot->set_item(Ref<Item>());
 	}
 	emit_signal("updated_transaction_slot");
 }
 
 bool InventoryHandler::drop(const Ref<Item> &item, const int &amount) {
+	ERR_FAIL_COND_V(item.is_null(), false);
+	ERR_FAIL_COND_V(item->get_definition().is_null(), false);
 	if (item->get_definition()->get_properties().has("dropped_item")) {
 		String path = item->get_definition()->get_properties()["dropped_item"];
-		for (size_t i = 0; i < amount; i++) {
+		// We have i < 1000 to have some enforced upper limit preventing long loops
+		for (size_t i = 0; i < amount && i < 1000; i++) {
 			emit_signal("request_drop_obj", path, item);
 		}
 		return true;
@@ -103,6 +107,9 @@ bool InventoryHandler::drop(const Ref<Item> &item, const int &amount) {
 }
 
 int InventoryHandler::add_to_inventory(Inventory *inventory, const Ref<Item> item, const int &amount, bool drop_excess) {
+	ERR_FAIL_COND_V(inventory == nullptr, amount);
+	ERR_FAIL_COND_V(item.is_null(), amount);
+
 	int value_no_added = inventory->add(item, amount);
 	emit_signal("added", item, amount - value_no_added);
 	if (drop_excess) {
@@ -115,6 +122,8 @@ int InventoryHandler::add_to_inventory(Inventory *inventory, const Ref<Item> ite
 void InventoryHandler::drop_from_inventory(const int &slot_index, const int &amount, Inventory *inventory) {
 	if (inventory == nullptr)
 		inventory = get_inventory(0);
+	ERR_FAIL_COND(inventory == nullptr);
+	ERR_FAIL_COND(slot_index < 0 || slot_index >= inventory->get_slots().size());
 	if (inventory->get_slots().size() <= slot_index)
 		return;
 	if (inventory->is_empty_slot(slot_index))
@@ -129,16 +138,23 @@ void InventoryHandler::drop_from_inventory(const int &slot_index, const int &amo
 }
 
 bool InventoryHandler::pick_to_inventory(Node *dropped_item, Inventory *inventory) {
+	ERR_FAIL_NULL_V(dropped_item, false);
+
 	if (inventory == nullptr) {
 		inventory = get_inventory(0);
 	}
-	if (!dropped_item->get("is_pickable")) {
+	ERR_FAIL_NULL_V(inventory, false);
+
+	if (!dropped_item->get("is_pickable")){
 		return false;
 	}
-	Ref<Item> item = dropped_item->get("item");
-	if (item == nullptr || item->get_definition() == nullptr) {
-		ERR_PRINT("Item or Item Definition in dropped_item is null!");
-	}
+	Variant item_variant = dropped_item->get("item");
+	ERR_FAIL_COND_V(item_variant.get_type() != Variant::OBJECT, false);
+
+    Ref<Item> item = item_variant;
+	ERR_FAIL_COND_V(item.is_null(), false);
+	ERR_FAIL_COND_V(item->get_definition().is_null(), false);
+
 	if (add_to_inventory(inventory, item) == 0) {
 		emit_signal("picked", dropped_item);
 		dropped_item->queue_free();
@@ -218,6 +234,7 @@ bool InventoryHandler::is_open_any_inventory() const {
 }
 
 bool InventoryHandler::is_open(Inventory *inventory) const {
+	ERR_FAIL_NULL_V(inventory, false);
 	NodePath inventory_path = get_path_to(inventory);
 	return inventory->get_is_open() && opened_inventories.find(inventory_path) != -1;
 }


### PR DESCRIPTION
Hi!

I'm not super familiar with GDExtensions so I wasn't able to attach a debugger and pinpoint exactly where the crash was (although I think it was probably in Inventory::add or Inventory::add_to_slot. I made a couple of changes to add some extra validation on pointers/objects and haven't encountered any crashes since then when picking up a DroppedItem3D (in a multiplayer set-up).