### PR TITLE
Fix Inventory.drop() default value bindings

### DIFF
--- a/doc_classes/Inventory.xml
+++ b/doc_classes/Inventory.xml
@@ -132,8 +132,8 @@
 		</method>
 		<method name="drop">
 			<return type="bool" />
-			<param index="0" name="item_id" type="String" default="1" />
-			<param index="1" name="amount" type="int" default="{}" />
+			<param index="0" name="item_id" type="String" />
+			<param index="1" name="amount" type="int" default="1" />
 			<param index="2" name="properties" type="Dictionary" default="{}" />
 			<description>
 			</description>

--- a/src/core/inventory.cpp
+++ b/src/core/inventory.cpp
@@ -700,7 +700,7 @@ void Inventory::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("split", "stack_index", "amount"), &Inventory::split, DEFVAL(1));
 	ClassDB::bind_method(D_METHOD("transfer_at", "stack_index", "destination", "destination_stack_index", "amount"), &Inventory::transfer_at, DEFVAL(1));
 	ClassDB::bind_method(D_METHOD("transfer", "stack_index", "destination", "amount"), &Inventory::transfer, DEFVAL(1));
-	ClassDB::bind_method(D_METHOD("drop", "item_id", "amount", "properties"), &Inventory::drop, DEFVAL(1), DEFVAL(Dictionary()), DEFVAL(Dictionary()));
+	ClassDB::bind_method(D_METHOD("drop", "item_id", "amount", "properties"), &Inventory::drop, DEFVAL(1), DEFVAL(Dictionary()));
 	ClassDB::bind_method(D_METHOD("drop_from_inventory", "stack_index", "amount", "properties"), &Inventory::drop_from_inventory, DEFVAL(1), DEFVAL(Dictionary()));
 	ClassDB::bind_method(D_METHOD("add_to_stack", "stack", "item_id", "amount", "properties"), &Inventory::add_to_stack, DEFVAL(1), DEFVAL(Dictionary()));
 	ClassDB::bind_method(D_METHOD("remove_from_stack", "stack", "item_id", "amount"), &Inventory::remove_from_stack, DEFVAL(1));


### PR DESCRIPTION
removed default value from parameter "item_id"
Corrected default value of "amount" from empty dictionary to integer 1