### PR TITLE
191 inventory editor fix

### DIFF
--- a/addons/inventory-system/editor/inventory_editor.gd
+++ b/addons/inventory-system/editor/inventory_editor.gd
@@ -244,6 +244,9 @@ func _on_export_menu_id_pressed(id: int) -> void:
 
 
 func _on_new_item_menu_id_pressed() -> void:
+	if database.items.any(func(item) -> bool: return item.id == ""):
+		push_warning("Item with empty id can exist only once.")
+		return
 	var new_item_definition = ItemDefinition.new()
 	new_item_definition.name = "New Item"
 	database.add_new_item(new_item_definition)
@@ -258,6 +261,9 @@ func _on_new_recipe_menu_id_pressed() -> void:
 
 
 func _on_new_craft_station_menu_id_pressed() -> void:
+	if database.stations_type.any(func(station_type) -> bool: return station_type.id == ""):
+		push_warning("Craft station type with empty id can exist only once.")
+		return
 	var new_craft_station_type = CraftStationType.new()
 	new_craft_station_type.name = "New Craft Station Type"
 	database.stations_type.append(new_craft_station_type)
@@ -266,6 +272,9 @@ func _on_new_craft_station_menu_id_pressed() -> void:
 
 
 func _on_new_item_category_menu_id_pressed() -> void:
+	if database.item_categories.any(func(item_category) -> bool: return item_category.id == ""):
+		push_warning("Item category with empty id can exist only once.")
+		return
 	var new_item_category = ItemCategory.new()
 	new_item_category.name = "New Item Category"
 	database.item_categories.append(new_item_category)

--- a/addons/inventory-system/editor/inventory_editor.gd
+++ b/addons/inventory-system/editor/inventory_editor.gd
@@ -247,10 +247,10 @@ func _on_export_menu_id_pressed(id: int) -> void:
 
 func _on_new_item_menu_id_pressed() -> void:
 	if database.items.any(func(item) -> bool: return item.id == ""):
-		push_warning("Item with empty id can exist only once.")
+		push_warning("Item definition with empty id can exist only once.")
 		return
 	var new_item_definition = ItemDefinition.new()
-	new_item_definition.name = "New Item"
+	new_item_definition.name = "New Item defition"
 	database.add_new_item(new_item_definition)
 	save_file()
 	load_database(database)

--- a/addons/inventory-system/editor/inventory_editor.gd
+++ b/addons/inventory-system/editor/inventory_editor.gd
@@ -24,6 +24,8 @@ const NEW_ITEM_FROM_RESOURCE = 101
 # The Inventory System plugin
 var editor_plugin : InventorySystemEditorPlugin
 
+@onready var tab_container : TabContainer = $MarginContainer/VBoxContainer/Content/TabContainer
+
 @onready var items_editor : ItemsEditor = get_node("MarginContainer/VBoxContainer/Content/TabContainer/Items")
 @onready var recipes_editor : RecipesEditor = %Recipes
 @onready var craft_stations_editor : CraftStationTypesEditor = $"MarginContainer/VBoxContainer/Content/TabContainer/Craft Stations"
@@ -252,12 +254,14 @@ func _on_new_item_menu_id_pressed() -> void:
 	database.add_new_item(new_item_definition)
 	save_file()
 	load_database(database)
+	tab_container.current_tab = 0
 
 
 func _on_new_recipe_menu_id_pressed() -> void:
 	database.add_recipe()
 	save_file()
 	load_database(database)
+	tab_container.current_tab = 1
 
 
 func _on_new_craft_station_menu_id_pressed() -> void:
@@ -269,6 +273,7 @@ func _on_new_craft_station_menu_id_pressed() -> void:
 	database.stations_type.append(new_craft_station_type)
 	save_file()
 	load_database(database)
+	tab_container.current_tab = 2
 
 
 func _on_new_item_category_menu_id_pressed() -> void:
@@ -280,6 +285,7 @@ func _on_new_item_category_menu_id_pressed() -> void:
 	database.item_categories.append(new_item_category)
 	save_file()
 	load_database(database)
+	tab_container.current_tab = 3
 
 
 func remove_item_definition(item : ItemDefinition):

--- a/addons/inventory-system/editor/inventory_editor.gd
+++ b/addons/inventory-system/editor/inventory_editor.gd
@@ -245,6 +245,7 @@ func _on_export_menu_id_pressed(id: int) -> void:
 
 func _on_new_item_menu_id_pressed() -> void:
 	var new_item_definition = ItemDefinition.new()
+	new_item_definition.name = "New Item"
 	database.add_new_item(new_item_definition)
 	save_file()
 	load_database(database)

--- a/addons/inventory-system/editor/inventory_editor.gd
+++ b/addons/inventory-system/editor/inventory_editor.gd
@@ -250,7 +250,7 @@ func _on_new_item_menu_id_pressed() -> void:
 		push_warning("Item definition with empty id can exist only once.")
 		return
 	var new_item_definition = ItemDefinition.new()
-	new_item_definition.name = "New Item defition"
+	new_item_definition.name = "New Item definition"
 	database.add_new_item(new_item_definition)
 	save_file()
 	load_database(database)


### PR DESCRIPTION
This relates to #191

* added a missing "new item definition description"
* allow only one empty entry (fix bug): for item definition, craft station type and item category. the recipe has no id.
* switch to tab where the empty entry was added
