### PR TITLE
Fix: item_added signal, is_full(), is_empty(), and inserting additional stacks -- Take Two

### DIFF
--- a/doc_classes/Inventory.xml
+++ b/doc_classes/Inventory.xml
@@ -21,6 +21,7 @@
 			<param index="1" name="amount" type="int" default="1" />
 			<param index="2" name="properties" type="Dictionary" default="{}" />
 			<param index="3" name="drop_excess" type="bool" default="false" />
+			<param index="4" name="can_emit_item_added_signal" type="bool" default="true" />
 			<description>
 				Adds an amount of [ItemStack] to the inventory and returns the amount that cannot be added.
 				[codeblocks]
@@ -47,6 +48,7 @@
 			<param index="1" name="item_id" type="String" />
 			<param index="2" name="amount" type="int" default="1" />
 			<param index="3" name="properties" type="Dictionary" default="{}" />
+			<param index="4" name="can_emit_item_added_signal" type="bool" default="true" />
 			<description>
 				Adds an amount of [ItemStack](with string id from [InventoryDatabase]) to a specific inventory stack index and returns the amount that cannot be added.
 				[codeblocks]
@@ -61,7 +63,8 @@
 			<param index="0" name="item_id" type="String" />
 			<param index="1" name="amount" type="int" default="1" />
 			<param index="2" name="properties" type="Dictionary" default="{}" />
-			<param index="3" name="can_emit_signal" type="bool" default="true" />
+			<param index="3" name="can_emit_stack_added_signal" type="bool" default="true" />
+			<param index="4" name="can_emit_item_added_signal" type="bool" default="true" />
 			<description>
 				Add [param item_id] to a new stack, ignoring the possibility of adding that item to an existing stack.
 			</description>
@@ -72,6 +75,7 @@
 			<param index="1" name="item_id" type="String" />
 			<param index="2" name="amount" type="int" default="1" />
 			<param index="3" name="properties" type="Dictionary" default="{}" />
+			<param index="4" name="can_emit_item_added_signal" type="bool" default="true" />
 			<description>
 				Adds an amount of item_id to the specified stack and returns the amount that cannot be added.
 				[codeblocks]

--- a/src/core/inventory.h
+++ b/src/core/inventory.h
@@ -17,7 +17,7 @@ private:
 	void _insert_stack(int stack_index);
 	void _remove_stack_at(int stack_index);
 	void _call_events(int old_amount);
-	int _add_to_stack(int stack_index, const String &item_id, int amount = 1, const Dictionary &properties = Dictionary());
+	int _add_to_stack(int stack_index, const String &item_id, int amount = 1, const Dictionary &properties = Dictionary(), const bool can_emit_item_added_signal = true);
 	int _remove_from_stack(int stack_index, const String &item_id, int amount = 1);
 
 protected:
@@ -51,10 +51,10 @@ public:
 	int amount_of_item(const String &item) const;
 	int amount_of_category(const Ref<ItemCategory> &category) const;
 	int amount() const;
-	virtual int add(const String &item_id, const int &amount = 1, const Dictionary &properties = Dictionary(), const bool &drop_excess = false);
-	int add_at_index(const int &stack_index, const String &item_id, const int &amount = 1, const Dictionary &properties = Dictionary());
-	int add_on_new_stack(const String &item_id, const int &amount = 1, const Dictionary &properties = Dictionary(), const bool can_emit_signal = true);
-	int insert_stack(const int &stack_index, const String &item_id, const int &amount = 1, const Dictionary &properties = Dictionary(), const bool can_emit_signal = true);
+	virtual int add(const String &item_id, const int &amount = 1, const Dictionary &properties = Dictionary(), const bool &drop_excess = false, const bool can_emit_item_added_signal = true);
+	int add_at_index(const int &stack_index, const String &item_id, const int &amount = 1, const Dictionary &properties = Dictionary(), const bool can_emit_item_added_signal = true);
+	int add_on_new_stack(const String &item_id, const int &amount = 1, const Dictionary &properties = Dictionary(), const bool can_emit_stack_added_signal = true, const bool can_emit_item_added_signal = true);
+	int insert_stack(const int &stack_index, const String &item_id, const int &amount = 1, const Dictionary &properties = Dictionary(), const bool can_emit_stack_added_signal = true, const bool can_emit_item_added_signal = true);
 	void remove_stack(const int &stack_index);
 	int remove(const String &item_id, const int &amount = 1);
 	int remove_at(const int &stack_index, const String &item_id, const int &amount = 1);
@@ -64,7 +64,7 @@ public:
 	virtual bool drop(const String &item_id, const int &amount, const Dictionary &properties);
 	void drop_all_stacks();
 	void drop_from_inventory(const int &stack_index, const int &amount = 1, const Dictionary &properties = Dictionary());
-	int add_to_stack(Ref<ItemStack> stack, const String &item_id, const int &amount, const Dictionary &properties = Dictionary());
+	int add_to_stack(Ref<ItemStack> stack, const String &item_id, const int &amount, const Dictionary &properties = Dictionary(), const bool can_emit_item_added_signal);
 	int remove_from_stack(Ref<ItemStack> stack, const String &item_id, const int &amount);
 	int get_max_stack_of_stack(const Ref<ItemStack> &stack, Ref<ItemDefinition> &item) const;
 	bool contains_category_in_stack(const Ref<ItemStack> &slot, const Ref<ItemCategory> &category) const;

--- a/src/core/inventory.h
+++ b/src/core/inventory.h
@@ -64,7 +64,7 @@ public:
 	virtual bool drop(const String &item_id, const int &amount, const Dictionary &properties);
 	void drop_all_stacks();
 	void drop_from_inventory(const int &stack_index, const int &amount = 1, const Dictionary &properties = Dictionary());
-	int add_to_stack(Ref<ItemStack> stack, const String &item_id, const int &amount, const Dictionary &properties = Dictionary(), const bool can_emit_item_added_signal);
+	int add_to_stack(Ref<ItemStack> stack, const String &item_id, const int &amount, const Dictionary &properties = Dictionary(), const bool can_emit_item_added_signal = true);
 	int remove_from_stack(Ref<ItemStack> stack, const String &item_id, const int &amount);
 	int get_max_stack_of_stack(const Ref<ItemStack> &stack, Ref<ItemDefinition> &item) const;
 	bool contains_category_in_stack(const Ref<ItemStack> &slot, const Ref<ItemCategory> &category) const;


### PR DESCRIPTION
Fixes:
- [x] item_added signal was not emitting as confirmed #205 
- [x] is_full() would return true when inventory is empty
- [x] is_empty() was scanning the entire stack array instead of aborting on the first item found
- [x] add calling add_on_new_stack resulting in new stacks not added when the inventory has space to handle additional stacks.
- [x] Introduced new can_emit flags granular for stack and items. Fix for bug that was introduced and reverted in #206 


Not quite sure how to update the documentation.
I ran out of time today fighting with installing sphinx_rtd_dark_mode or arch linux.